### PR TITLE
Pinning pyyaml dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ Flask-Migrate==2.4.0
 psycopg2-binary==2.7.7
 pytest-cov==2.6.1
 pytest-mock==1.10.1
-pyyaml==4.2b1
+pyyaml==5.1
 requests==2.21.0
 SQLAlchemy-Utils==0.33.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ Flask-Migrate==2.4.0
 psycopg2-binary==2.7.7
 pytest-cov==2.6.1
 pytest-mock==1.10.1
-pyyaml>=4.2b1
+pyyaml==4.2b1
 requests==2.21.0
 SQLAlchemy-Utils==0.33.11


### PR DESCRIPTION
Thanks for the opportunity to learn/read about pinning dependencies! 
Pyyaml's current stable version is 5.1. Not sure if we needed/wanted to move to that one yet.